### PR TITLE
TRA-17462 - Add updated_at params for zammad dag

### DIFF
--- a/airflow/dags/dlt_pipelines/zammad_pipeline.py
+++ b/airflow/dags/dlt_pipelines/zammad_pipeline.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from typing import Iterable, Optional
 from dlt.sources.helpers.rest_client import RESTClient
 from dlt.sources.helpers.rest_client.auth import BearerTokenAuth
-
+from airflow.operators.python import get_current_context
 # Set up logging
 import logging
 
@@ -89,6 +89,19 @@ def get_last_updated_at_from_response(
     return last_updated_at
 
 
+def _set_dlt_updated_at_filter(context, dlt_updated_at) -> str:
+    """
+    Set the updated_at filter for the DLT pipeline.
+    If the updated_at is provided in the context, use it to set the updated_at filter.
+    Otherwise, use the last value of the DLT pipeline.
+    """
+    try:        
+        updated_at = datetime.fromisoformat(context["dag_run"].conf.get("updated_at")) if context and context.get("dag_run") else None
+        logger.info(f"Force updated at: {updated_at} from context")
+    except Exception:
+        updated_at = datetime.fromisoformat(dlt_updated_at.last_value) - timedelta(days=1)
+    return updated_at
+
 @dlt.resource(
     write_disposition="merge", primary_key="id", max_table_nesting=0, parallelized=True
 )
@@ -101,7 +114,8 @@ def tickets(
     """Fetch tickets from the Zammad API."""
     path = "/tickets/search"
 
-    updated_at = datetime.fromisoformat(updated_at.last_value) - timedelta(days=1)
+    updated_at = _set_dlt_updated_at_filter(context=get_current_context(), dlt_updated_at=updated_at)
+
     params = {
         "query": f"updated_at:>{updated_at:%Y-%m-%d}",
         "page": 1,
@@ -143,7 +157,8 @@ def users(
     """Fetch users from the Zammad API."""
     path = "/users/search"
 
-    updated_at = datetime.fromisoformat(updated_at.last_value) - timedelta(days=1)
+    updated_at = _set_dlt_updated_at_filter(context=get_current_context(), dlt_updated_at=updated_at)
+
     params = {
         "query": f"updated_at:>{updated_at:%Y-%m-%d}",
         "page": 1,
@@ -188,7 +203,8 @@ def organizations(
     """Fetch organizations from the Zammad API."""
     path = "/organizations/search"
 
-    updated_at = datetime.fromisoformat(updated_at.last_value) - timedelta(days=1)
+    updated_at = _set_dlt_updated_at_filter(context=get_current_context(), dlt_updated_at=updated_at)
+
     params = {
         "query": f"updated_at:>{updated_at:%Y-%m-%d}",
         "page": 1,
@@ -219,7 +235,8 @@ def text_modules(
     """Fetch organizations from the Zammad API."""
     path = "/text_modules/search"
 
-    updated_at = datetime.fromisoformat(updated_at.last_value) - timedelta(days=1)
+    updated_at = _set_dlt_updated_at_filter(context=get_current_context(), dlt_updated_at=updated_at)
+
     params = {
         "query": f"updated_at:>{updated_at:%Y-%m-%d}",
         "page": 1,

--- a/airflow/dags/dlt_pipelines/zammad_pipeline_dag.py
+++ b/airflow/dags/dlt_pipelines/zammad_pipeline_dag.py
@@ -1,8 +1,7 @@
 from datetime import timedelta
 import os
 from airflow.decorators import dag
-from airflow.models import Connection
-
+from airflow.models import Connection, Param
 import dlt
 from dlt.common import pendulum
 from dlt.helpers.airflow_helper import PipelineTasksGroup
@@ -38,6 +37,12 @@ default_task_args = {
     max_active_runs=1,
     default_args=default_task_args,
     on_failure_callback=send_alert_to_mattermost,
+    params={"updated_at": Param(
+            type=["null", "string"],
+            format="date-time",
+            default=None,
+            description="The date and time from which to start loading data from the Zammad API. Format: YYYY-MM-DDTHH:MM:SSZ"
+        )},
 )
 def load_zammad_data():
     # set `use_data_folder` to True to store temporary data on the `data` bucket. Use only when it does not fit on the local storage


### PR DESCRIPTION
Tickets since 2025-10-20 are not loaded because DLT already run for these dates (even if it didn't upload all the tickets due to permission issues)
- Implement a fix to enable reloading data with a DAG parameter