### PR TITLE
Tra 17439 improve retrieve companies dag

### DIFF
--- a/airflow/dags/jobs_vigiedechets/retrieve_companies_dag.py
+++ b/airflow/dags/jobs_vigiedechets/retrieve_companies_dag.py
@@ -231,6 +231,31 @@ def retrieve_companies_scalingo():
                 f"SUCCESS: Container {container_info_obj.container_id} completed successfully"
             )
 
+            # Parse and display statistics from summary line
+            summary_pattern = (
+                r"Summary\s*—\s*created:\s*(\d+),\s*skipped duplicates:\s*(\d+),"
+                r"\s*skipped existing:\s*(\d+),\s*failed:\s*(\d+)"
+            )
+            summary_match = re.search(summary_pattern, container_logs, re.IGNORECASE)
+            if summary_match:
+                created = summary_match.group(1)
+                skipped_duplicates = summary_match.group(2)
+                skipped_existing = summary_match.group(3)
+                failed = summary_match.group(4)
+                logger.info("=" * 60)
+                logger.info("RETRIEVE COMPANIES STATISTICS:")
+                logger.info(f"  Created: {created}")
+                logger.info(f"  Skipped duplicates: {skipped_duplicates}")
+                logger.info(f"  Skipped existing: {skipped_existing}")
+                logger.info(f"  Failed: {failed}")
+                logger.info("=" * 60)
+            else:
+                logger.warning(
+                    "Could not find summary statistics in logs. "
+                    "Expected format: 'Summary — created: X, skipped duplicates: Y, "
+                    "skipped existing: Z, failed: W'"
+                )
+
         except subprocess.CalledProcessError as e:
             error_output = e.stderr if e.stderr else str(e)
             raise ScalingoCommandError(

--- a/airflow/dags/jobs_vigiedechets/retrieve_companies_dag.py
+++ b/airflow/dags/jobs_vigiedechets/retrieve_companies_dag.py
@@ -181,7 +181,7 @@ def retrieve_companies_scalingo():
         """
 
         container_info_obj = ContainerInfo(**container_info)
-        max_wait_time = 3600  # 1 hour max wait time
+        max_wait_time = 2 * 60 * 60  # 2 hours max wait time
         check_interval = 10  # Check every 10 seconds
         start_time = time.time()
 


### PR DESCRIPTION
## Description

Fix BUG:
- DAG retrive_companies_Dag fail because timeout is too short (job tyake smore than 1 hour)

We want to know more about companies creation to understand why there is a mismatch between map export and data in the data warehouse

### Type de changement
- [ ] Nouvelle fonctionnalité (ajout d'un pipeline, transformation, etc.)
- [x] Correction de bug
- [ ] Refactorisation
- [ ] Amélioration de performance
- [ ] Documentation
- [ ] Infrastructure / Configuration
- [ ] Autre (précisez):

### Code
- Increase retrieve_companies job timeout to 2 hours
- Add logging and statistics to know why all companies are not created## Testing

```bash
# Commandes de test exécutées
```
Run Airflow DAG : retrieve_companies_dag
```

## Données
### Backward compatibility
- [x] Le changement est backward compatible

## Checklist avant merge

- [x] Code reviewed (auto-review effectué)
- [x] Tests passent localement et en CI/CD
- [x] Pas de données sensibles committées
- [x] Commits atomiques et messages clairs
- [x] Branch à jour avec `main` (rebase si nécessaire)
- [x] Linter/formatter exécuté (`ruff`, `sqlfluff`, etc.)
- [x] Documentation et commentaires à jour
- [x] Aucune dépendance problématique ajoutée
