### PR TITLE
Tra 17651 update installations 2026

### DIFF
--- a/dbt/models/refined_zone/icpe/int_dangerous_installations.sql
+++ b/dbt/models/refined_zone/icpe/int_dangerous_installations.sql
@@ -12,7 +12,7 @@ with installations as (
         groupArray(distinct code_aiot) as codes_aiot,
         sum(quantite_totale)          as quantite_autorisee
     from
-        {{ ref('installations_rubriques_2025') }}
+        {{ ref('installations_rubriques') }}
     where
         siret is not null
         and rubrique in ('2770', '2790', '2760-1')

--- a/dbt/models/refined_zone/icpe/int_non_dangerous_installations.sql
+++ b/dbt/models/refined_zone/icpe/int_non_dangerous_installations.sql
@@ -18,7 +18,7 @@ with installations as (
             as quantite_autorisee,
         max(c.capacite_50pct)          as objectif_quantite_traitee
     from
-        {{ ref('installations_rubriques_2025') }} i
+        {{ ref('installations_rubriques') }} i
     left join {{ ref('isdnd_capacites_limites_50pct') }} c on i.siret=c.siret and match(rubrique,'^2760\-2.*')        
     where
         siret is not null

--- a/dbt/models/refined_zone/icpe/liste_des_installations.sql
+++ b/dbt/models/refined_zone/icpe/liste_des_installations.sql
@@ -26,7 +26,7 @@ gun_installations as (
         groupArray(distinct code_aiot)                  as codes_aiot,
         arraySort(groupArray(distinct rubrique)) as rubriques
     from
-        {{ ref('installations_rubriques_2025') }} ir
+        {{ ref('installations_rubriques') }} ir
     where
         (libelle_etat_site = 'Avec titre') -- noqa: LXR
         and (etat_administratif_rubrique in ('En vigueur', 'A l''arrêt'))

--- a/dbt/models/refined_zone/vigiedechets/cartographie_icpe/cartographie_icpe_installations.sql
+++ b/dbt/models/refined_zone/vigiedechets/cartographie_icpe/cartographie_icpe_installations.sql
@@ -43,7 +43,7 @@ installations as (
         i.code_insee,
         ir.rubrique
     from
-        {{ ref('installations_rubriques_2025') }} as ir
+        {{ ref('installations_rubriques') }} as ir
     left join {{ ref('installations') }} as i on ir.code_aiot = i.code_aiot
     where
         (ir.libelle_etat_site = 'Avec titre') -- noqa: LXR

--- a/dbt/models/sources/raw_zone_icpe.yml
+++ b/dbt/models/sources/raw_zone_icpe.yml
@@ -171,3 +171,56 @@ sources:
             data_type: Date32
           - name: _inserted_at
             data_type: DateTime64(9, 'Europe/Paris')
+      - name: installations_rubriques_2026
+        identifier: installations_rubriques_2026
+        description: >
+          Nouvelles données sur les installations et les rubriques (mise à jour 2026)
+        columns:
+          - name: Raison sociale/nom
+            data_type: string
+          - name: SIRET
+            data_type: string
+          - name: Code AIOT
+            data_type: string
+          - name: X
+            data_type: int256
+          - name: Y
+            data_type: int256
+          - name: Etat du site (code)
+            data_type: string
+          - name: Etat du site (libellé)
+            data_type: string
+          - name: Numéro rubrique
+            data_type: string
+          - name: Régime
+            data_type: string
+          - name: Quantité projet
+            data_type: float32
+          - name: Quantité totale
+            data_type: float32
+          - name: Capacité projet
+            data_type: float32
+          - name: Capacité totale
+            data_type: float32
+          - name: Unité
+            data_type: string
+          - name: Etat technique de la rubrique
+            data_type: string
+          - name: Etat administratif de la rubrique
+            data_type: string
+          - name: Adresse partie 1
+            data_type: String
+          - name: Adresse partie 2
+            data_type: String
+          - name: Code postal
+            data_type: String
+          - name: Commune
+            data_type: String
+          - name: Coordonnée X
+            data_type: Int64
+          - name: Coordonnée Y
+            data_type: Int64
+          - name: Date de l'archivage de l'AIOT
+            data_type: Date32
+          - name: _inserted_at
+            data_type: DateTime64(9, 'Europe/Paris')

--- a/dbt/models/trusted_zone/icpe/_installations_rubriques.yml
+++ b/dbt/models/trusted_zone/icpe/_installations_rubriques.yml
@@ -1,0 +1,37 @@
+version: 2
+models:
+  - name: installations_rubriques
+    description: >
+      Modèle unifié pour les données sur les installations et les rubriques.
+      Pointe vers la dernière version disponible (actuellement 2026).
+      Une ligne par installation et rubrique      
+    columns:
+      - name: raison_sociale
+        data_type: string
+      - name: siret
+        data_type: string
+      - name: code_aiot
+        data_type: string
+      - name: code_etat_site
+        data_type: string
+      - name: libelle_etat_site
+        data_type: string
+      - name: regime
+        data_type: string
+      - name: quantite_projet
+        data_type: float32
+      - name: capacite_projet
+        data_type: float32
+      - name: capacite_totale
+        data_type: float32
+      - name: unite
+        data_type: string
+      - name: etat_technique_rubrique
+        data_type: string
+      - name: etat_administratif_rubrique
+        data_type: string
+      - name: quantite_totale
+        data_type: float32
+      - name: rubrique
+        data_type: string
+

--- a/dbt/models/trusted_zone/icpe/_installations_rubriques_2026.yml
+++ b/dbt/models/trusted_zone/icpe/_installations_rubriques_2026.yml
@@ -1,0 +1,37 @@
+version: 2
+models:
+  - name: installations_rubriques_2026
+    description: >
+      Données sur les installations et les rubriques pour l'année 2026
+      Fichier mis à jour le 02/01/2026
+      Une ligne par installation et rubrique      
+    columns:
+      - name: raison_sociale
+        data_type: string
+      - name: siret
+        data_type: string
+      - name: code_aiot
+        data_type: string
+      - name: code_etat_site
+        data_type: string
+      - name: libelle_etat_site
+        data_type: string
+      - name: regime
+        data_type: string
+      - name: quantite_projet
+        data_type: float32
+      - name: capacite_projet
+        data_type: float32
+      - name: capacite_totale
+        data_type: float32
+      - name: unite
+        data_type: string
+      - name: etat_technique_rubrique
+        data_type: string
+      - name: etat_administratif_rubrique
+        data_type: string
+      - name: quantite_totale
+        data_type: float32
+      - name: rubrique
+        data_type: string
+

--- a/dbt/models/trusted_zone/icpe/installations_rubriques.sql
+++ b/dbt/models/trusted_zone/icpe/installations_rubriques.sql
@@ -1,0 +1,17 @@
+select
+    raison_sociale,
+    siret,
+    code_aiot,
+    code_etat_site,
+    libelle_etat_site,
+    regime,
+    quantite_projet,
+    capacite_projet,
+    capacite_totale,
+    unite,
+    etat_technique_rubrique,
+    etat_administratif_rubrique,
+    quantite_totale,
+    rubrique
+from {{ ref('installations_rubriques_2026') }}
+

--- a/dbt/models/trusted_zone/icpe/installations_rubriques_2026.sql
+++ b/dbt/models/trusted_zone/icpe/installations_rubriques_2026.sql
@@ -1,0 +1,50 @@
+with source as (
+    select *
+    from {{ source('raw_zone_icpe', 'installations_rubriques_2026') }}
+    where
+        "_inserted_at"
+        = (
+            select max("_inserted_at")
+            from
+                {{ source('raw_zone_icpe', 'installations_rubriques_2026') }}
+        )
+),
+
+renamed as (
+    select
+        "Raison sociale/nom"                as raison_sociale,
+        "SIRET" as siret,
+        "Code AIOT"                         as code_aiot,
+        "X" as x,
+        "Y" as y,
+        "Etat du site (code)"               as code_etat_site,
+        "Etat du site (libellé)"            as libelle_etat_site,
+        "Numéro rubrique"                   as rubrique,
+        "Régime"                            as regime,
+        "Quantité projet"                   as quantite_projet,
+        "Quantité totale"                   as quantite_totale,
+        "Capacité projet"                   as capacite_projet,
+        "Capacité totale"                   as capacite_totale,
+        "Unité"                             as unite,
+        "Etat technique de la rubrique"     as etat_technique_rubrique,
+        "Etat administratif de la rubrique" as etat_administratif_rubrique
+    from source
+)
+
+select
+    raison_sociale,
+    siret,
+    code_aiot,
+    code_etat_site,
+    libelle_etat_site,
+    regime,
+    quantite_projet,
+    capacite_projet,
+    capacite_totale,
+    unite,
+    etat_technique_rubrique,
+    etat_administratif_rubrique,
+    coalesce(quantite_totale, capacite_totale) as quantite_totale,
+    replaceAll(rubrique, '.', '-')             as rubrique
+from renamed
+

--- a/scripts/integration/gun/load_gun_data_ch.py
+++ b/scripts/integration/gun/load_gun_data_ch.py
@@ -20,7 +20,7 @@ def load_gun_csv_file_to_dwh(
     dwh_username: str,
     dwh_password: str,
 ):
-    dst_table_name: str = "installations_rubriques_2025"
+    dst_table_name: str = "installations_rubriques_2026"
 
     GUN_TABLE_DDL = f"""
     CREATE TABLE IF NOT EXISTS raw_zone_icpe.{dst_table_name} (


### PR DESCRIPTION
## Description

Ajouter les modèles `installations_rubriques_2026` et `installations_rubriques` pour ajouter les nouvelles données et stabiliser les prochaines mises à jour

### Type de changement
- [x] Nouvelle fonctionnalité (ajout d'un pipeline, transformation, etc.)
- [ ] Correction de bug
- [ ] Refactorisation
- [ ] Amélioration de performance
- [ ] Documentation
- [ ] Infrastructure / Configuration
- [ ] Autre (précisez):

## Context et motivation

Nouvelles données GUN pour 2026
les modèles actuels contiennent les données 2024 et 2025
On veut une structure pérénne pour limiter les manipulations chaque année

## Changements techniques
- Modèle 2026 avec les nouvelles données
- Modèle qui pointe vers la dernière année

### Data
- Impact sur les sources de données: Modèles installations ICPE utilisent les nouvelles données GU


### Documentation des données
- [ ] Schéma mis à jour
- [ ] Documentation des colonnes à jour
- [ ] Commentaires dbt/code pour la complexité

## Checklist avant merge

- [x] Code reviewed (auto-review effectué)
- [x] Tests passent localement et en CI/CD
- [x] Pas de données sensibles committées
- [x] Commits atomiques et messages clairs
- [x] Branch à jour avec `main` (rebase si nécessaire)
- [x] Linter/formatter exécuté (`ruff`, `sqlfluff`, etc.)
- [x] Documentation et commentaires à jour
- [x] Aucune dépendance problématique ajoutée

## Notes supplémentaires

<!-- Contexte, décisions techniques, limitations connues, etc. -->

### Dépendances
- Nécessite le déploiement de:
- Attendez que ceci soit mergé en premier:

### Points de discussion
-
