### PR TITLE
feat(dbt): add is_dormant column to cartographie_etablissements model…

### DIFF
--- a/dbt/models/refined_zone/vigiedechets/cartographie_etablissements/_cartographie_etablissements.yml
+++ b/dbt/models/refined_zone/vigiedechets/cartographie_etablissements/_cartographie_etablissements.yml
@@ -137,3 +137,5 @@ models:
         data_type: Float64
       - name: longitude_td
         data_type: Float64
+      - name: is_dormant
+        data_type: Bool

--- a/dbt/models/refined_zone/vigiedechets/cartographie_etablissements/_cartographie_etablissements_geocoded.yml
+++ b/dbt/models/refined_zone/vigiedechets/cartographie_etablissements/_cartographie_etablissements_geocoded.yml
@@ -143,3 +143,5 @@ models:
         data_type: String
       - name: coords_h3_index
         data_type: UInt64
+      - name: is_dormant
+        data_type: Bool

--- a/dbt/models/refined_zone/vigiedechets/cartographie_etablissements/cartographie_etablissements.sql
+++ b/dbt/models/refined_zone/vigiedechets/cartographie_etablissements/cartographie_etablissements.sql
@@ -271,7 +271,8 @@ joined as (
         se.adresse                                     as adresse_insee,
         coalesce(
             c.name, nom_etablissement
-        )                                              as nom_etablissement
+        )                                              as nom_etablissement,
+        c.is_dormant
     from stats as s
     left join
         {{ ref('cartographie_etablissements_texs_dd') }} as et
@@ -359,5 +360,6 @@ select
     adresse_td,
     adresse_insee,
     latitude_td,
-    longitude_td
+    longitude_td,
+    is_dormant
 from joined

--- a/dbt/models/refined_zone/vigiedechets/cartographie_etablissements/cartographie_etablissements_geocoded.sql
+++ b/dbt/models/refined_zone/vigiedechets/cartographie_etablissements/cartographie_etablissements_geocoded.sql
@@ -87,8 +87,8 @@ select
         coalesce(c.longitude_td, cban.longitude),
         coalesce(c.latitude_td, cban.latitude),
         9
-    )              as coords_h3_index
-from {{ ref("cartographie_etablissements") }} as c
-left join
-    {{ ref("companies_geocoded_by_ban") }} as cban
-    on c.siret = cban.siret and cban.result_status = 'ok'
+    )              as coords_h3_index,
+    c.is_dormant
+from {{ ref("cartographie_etablissements")}} as c
+left join {{ ref("companies_geocoded_by_ban") }} as cban
+on c.siret = cban.siret and cban.result_status = 'ok'

--- a/dbt/models/trusted_zone/trackdechets/_company.yml
+++ b/dbt/models/trusted_zone/trackdechets/_company.yml
@@ -87,3 +87,5 @@ models:
         data_type: DateTime64(6, 'Europe/Paris')
       - name: has_enabled_registry_dnd_from_bsd_since
         data_type: DateTime64(6, 'Europe/Paris')
+      - name: is_dormant
+        data_type: Bool

--- a/dbt/models/trusted_zone/trackdechets/company.sql
+++ b/dbt/models/trusted_zone/trackdechets/company.sql
@@ -190,7 +190,10 @@ select
     ) as waste_vehicles_types,
     toNullable(
         toTimezone(toDateTime64("isDormantSince", 6), 'Europe/Paris')
-    ) as is_dormant_since,
+    ) as is_dormant_since,    
+    assumeNotNull(
+        toBool("isDormantSince" is not null)
+    ) as is_dormant,
     toNullable(
         toTimezone(
             toDateTime64("hasEnabledRegistryDndFromBsdSince", 6), 'Europe/Paris'


### PR DESCRIPTION
## Description

Ajout de la colonne `is_dormant` dans les modèles dbt pour permettre l'identification des établissements dormants dans la cartographie. Cette colonne est calculée à partir du champ `isDormantSince` de la source et est propagée depuis le modèle `company` (trusted_zone) jusqu'aux modèles `cartographie_etablissements` et `cartographie_etablissements_geocoded` (refined_zone).

Cette nouvelle colonne sera utilisée dans la [feature](https://favro.com/organization/ab14a4f0460a99a9d64d4945/37a331c647a38a191b2a1207?card=tra-16406).

### Type de changement
- [x] Nouvelle fonctionnalité (ajout d'un pipeline, transformation, etc.)
- [ ] Correction de bug
- [ ] Refactorisation
- [ ] Amélioration de performance
- [ ] Documentation
- [ ] Infrastructure / Configuration
- [ ] Autre (précisez):

## Changements techniques

<!-- Détaillez les modifications apportées -->

### Code
- Ajout de la colonne `is_dormant` dans le modèle `company` (trusted_zone) : calculée comme un booléen à partir de `isDormantSince` (non null = dormant)
- Propagation de `is_dormant` dans le modèle `cartographie_etablissements` : ajout dans la CTE `joined` et dans le SELECT final
- Ajout de `is_dormant` dans le modèle `cartographie_etablissements_geocoded` : récupération depuis `cartographie_etablissements`
- Mise à jour des schémas YAML pour documenter la nouvelle colonne dans tous les modèles concernés

### Data
- Impact sur les sources de données: Aucun changement, utilisation du champ `isDormantSince` existant
- Impact sur les transformations: Nouvelle colonne booléenne `is_dormant` disponible dans les modèles de cartographie
- Impact sur les tables finales: La table `cartographie_etablissements_geocoded` contient désormais l'information sur le statut dormant des établissements, permettant de filtrer ou analyser les établissements actifs vs dormants

### Infrastructure
- Aucun changement

## Testing

### Tests unitaires / Intégration
- [ ] Tests ajoutés/modifiés
- [x] Tous les tests passent (`pytest`, `dbt test`, etc.)

# Commandes de test exécutées
dbt test --select company
dbt test --select cartographie_etablissements
dbt test --select cartographie_etablissements_geocoded
dbt compile --select cartographie_etablissements_geocoded
