### PR TITLE
Hotfix latest registry

### DIFF
--- a/dbt/models/trusted_zone/trackdechets/latest_registry_incoming_texs.sql
+++ b/dbt/models/trusted_zone/trackdechets/latest_registry_incoming_texs.sql
@@ -1,9 +1,6 @@
 {{
   config(
-    materialized = 'incremental',
-    incremental_strategy = 'delete+insert',
-    unique_key = ['id'],
-    on_schema_change='append_new_columns'
+    materialized = 'table',
     )
 }}
 

--- a/dbt/models/trusted_zone/trackdechets/latest_registry_incoming_waste.sql
+++ b/dbt/models/trusted_zone/trackdechets/latest_registry_incoming_waste.sql
@@ -1,9 +1,6 @@
 {{
   config(
-    materialized = 'incremental',
-    incremental_strategy = 'delete+insert',
-    unique_key = ['id'],
-    on_schema_change='append_new_columns'
+    materialized = 'table',
     )
 }}
 

--- a/dbt/models/trusted_zone/trackdechets/latest_registry_outgoing_texs.sql
+++ b/dbt/models/trusted_zone/trackdechets/latest_registry_outgoing_texs.sql
@@ -1,9 +1,6 @@
 {{
   config(
-    materialized = 'incremental',
-    incremental_strategy = 'delete+insert',
-    unique_key = ['id'],
-    on_schema_change='append_new_columns'
+    materialized = 'table',
     )
 }}
 

--- a/dbt/models/trusted_zone/trackdechets/latest_registry_outgoing_waste.sql
+++ b/dbt/models/trusted_zone/trackdechets/latest_registry_outgoing_waste.sql
@@ -1,9 +1,6 @@
 {{
   config(
-    materialized = 'incremental',
-    incremental_strategy = 'delete+insert',
-    unique_key = ['id'],
-    on_schema_change='append_new_columns'
+    materialized = 'table',
     )
 }}
 

--- a/dbt/models/trusted_zone/trackdechets/latest_registry_ssd.sql
+++ b/dbt/models/trusted_zone/trackdechets/latest_registry_ssd.sql
@@ -1,9 +1,6 @@
 {{
   config(
-    materialized = 'incremental',
-    incremental_strategy = 'delete+insert',
-    unique_key = ['id'],
-    on_schema_change='append_new_columns'
+    materialized = 'table',
     )
 }}
 

--- a/dbt/models/trusted_zone/trackdechets/latest_registry_transported.sql
+++ b/dbt/models/trusted_zone/trackdechets/latest_registry_transported.sql
@@ -1,9 +1,6 @@
 {{
   config(
-    materialized = 'incremental',
-    incremental_strategy = 'delete+insert',
-    unique_key = ['id'],
-    on_schema_change='append_new_columns'
+    materialized = 'table',
     )
 }}
 

--- a/uv.lock
+++ b/uv.lock
@@ -1111,7 +1111,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7d/ec/bad1ac26764d26aa1353216fcbfa4670050f66d445448aafa227f8b16e80/greenlet-3.1.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:4afe7ea89de619adc868e087b4d2359282058479d7cfb94970adf4b55284574d", size = 274260, upload-time = "2024-09-20T17:08:07.301Z" },
     { url = "https://files.pythonhosted.org/packages/66/d4/c8c04958870f482459ab5956c2942c4ec35cac7fe245527f1039837c17a9/greenlet-3.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f406b22b7c9a9b4f8aa9d2ab13d6ae0ac3e85c9a809bd590ad53fed2bf70dc79", size = 649064, upload-time = "2024-09-20T17:36:47.628Z" },
     { url = "https://files.pythonhosted.org/packages/51/41/467b12a8c7c1303d20abcca145db2be4e6cd50a951fa30af48b6ec607581/greenlet-3.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c3a701fe5a9695b238503ce5bbe8218e03c3bcccf7e204e455e7462d770268aa", size = 663420, upload-time = "2024-09-20T17:39:21.258Z" },
-    { url = "https://files.pythonhosted.org/packages/27/8f/2a93cd9b1e7107d5c7b3b7816eeadcac2ebcaf6d6513df9abaf0334777f6/greenlet-3.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2846930c65b47d70b9d178e89c7e1a69c95c1f68ea5aa0a58646b7a96df12441", size = 658035, upload-time = "2024-09-20T17:44:26.501Z" },
     { url = "https://files.pythonhosted.org/packages/57/5c/7c6f50cb12be092e1dccb2599be5a942c3416dbcfb76efcf54b3f8be4d8d/greenlet-3.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99cfaa2110534e2cf3ba31a7abcac9d328d1d9f1b95beede58294a60348fba36", size = 660105, upload-time = "2024-09-20T17:08:42.048Z" },
     { url = "https://files.pythonhosted.org/packages/f1/66/033e58a50fd9ec9df00a8671c74f1f3a320564c6415a4ed82a1c651654ba/greenlet-3.1.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1443279c19fca463fc33e65ef2a935a5b09bb90f978beab37729e1c3c6c25fe9", size = 613077, upload-time = "2024-09-20T17:08:33.707Z" },
     { url = "https://files.pythonhosted.org/packages/19/c5/36384a06f748044d06bdd8776e231fadf92fc896bd12cb1c9f5a1bda9578/greenlet-3.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b7cede291382a78f7bb5f04a529cb18e068dd29e0fb27376074b6d0317bf4dd0", size = 1135975, upload-time = "2024-09-20T17:44:15.989Z" },
@@ -1120,7 +1119,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/57/0db4940cd7bb461365ca8d6fd53e68254c9dbbcc2b452e69d0d41f10a85e/greenlet-3.1.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:05175c27cb459dcfc05d026c4232f9de8913ed006d42713cb8a5137bd49375f1", size = 272990, upload-time = "2024-09-20T17:08:26.312Z" },
     { url = "https://files.pythonhosted.org/packages/1c/ec/423d113c9f74e5e402e175b157203e9102feeb7088cee844d735b28ef963/greenlet-3.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:935e943ec47c4afab8965954bf49bfa639c05d4ccf9ef6e924188f762145c0ff", size = 649175, upload-time = "2024-09-20T17:36:48.983Z" },
     { url = "https://files.pythonhosted.org/packages/a9/46/ddbd2db9ff209186b7b7c621d1432e2f21714adc988703dbdd0e65155c77/greenlet-3.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:667a9706c970cb552ede35aee17339a18e8f2a87a51fba2ed39ceeeb1004798a", size = 663425, upload-time = "2024-09-20T17:39:22.705Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/f9/9c82d6b2b04aa37e38e74f0c429aece5eeb02bab6e3b98e7db89b23d94c6/greenlet-3.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8a678974d1f3aa55f6cc34dc480169d58f2e6d8958895d68845fa4ab566509e", size = 657736, upload-time = "2024-09-20T17:44:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/d9/42/b87bc2a81e3a62c3de2b0d550bf91a86939442b7ff85abb94eec3fc0e6aa/greenlet-3.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:efc0f674aa41b92da8c49e0346318c6075d734994c3c4e4430b1c3f853e498e4", size = 660347, upload-time = "2024-09-20T17:08:45.56Z" },
     { url = "https://files.pythonhosted.org/packages/37/fa/71599c3fd06336cdc3eac52e6871cfebab4d9d70674a9a9e7a482c318e99/greenlet-3.1.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0153404a4bb921f0ff1abeb5ce8a5131da56b953eda6e14b88dc6bbc04d2049e", size = 615583, upload-time = "2024-09-20T17:08:36.85Z" },
     { url = "https://files.pythonhosted.org/packages/4e/96/e9ef85de031703ee7a4483489b40cf307f93c1824a02e903106f2ea315fe/greenlet-3.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:275f72decf9932639c1c6dd1013a1bc266438eb32710016a1c742df5da6e60a1", size = 1133039, upload-time = "2024-09-20T17:44:18.287Z" },
@@ -1128,7 +1126,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/1b/54336d876186920e185066d8c3024ad55f21d7cc3683c856127ddb7b13ce/greenlet-3.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:b42703b1cf69f2aa1df7d1030b9d77d3e584a70755674d60e710f0af570f3761", size = 299490, upload-time = "2024-09-20T17:17:09.501Z" },
     { url = "https://files.pythonhosted.org/packages/5f/17/bea55bf36990e1638a2af5ba10c1640273ef20f627962cf97107f1e5d637/greenlet-3.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f1695e76146579f8c06c1509c7ce4dfe0706f49c6831a817ac04eebb2fd02011", size = 643731, upload-time = "2024-09-20T17:36:50.376Z" },
     { url = "https://files.pythonhosted.org/packages/78/d2/aa3d2157f9ab742a08e0fd8f77d4699f37c22adfbfeb0c610a186b5f75e0/greenlet-3.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7876452af029456b3f3549b696bb36a06db7c90747740c5302f74a9e9fa14b13", size = 649304, upload-time = "2024-09-20T17:39:24.55Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/8e/d0aeffe69e53ccff5a28fa86f07ad1d2d2d6537a9506229431a2a02e2f15/greenlet-3.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4ead44c85f8ab905852d3de8d86f6f8baf77109f9da589cb4fa142bd3b57b475", size = 646537, upload-time = "2024-09-20T17:44:31.102Z" },
     { url = "https://files.pythonhosted.org/packages/05/79/e15408220bbb989469c8871062c97c6c9136770657ba779711b90870d867/greenlet-3.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8320f64b777d00dd7ccdade271eaf0cad6636343293a25074cc5566160e4de7b", size = 642506, upload-time = "2024-09-20T17:08:47.852Z" },
     { url = "https://files.pythonhosted.org/packages/18/87/470e01a940307796f1d25f8167b551a968540fbe0551c0ebb853cb527dd6/greenlet-3.1.1-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6510bf84a6b643dabba74d3049ead221257603a253d0a9873f55f6a59a65f822", size = 602753, upload-time = "2024-09-20T17:08:38.079Z" },
     { url = "https://files.pythonhosted.org/packages/e2/72/576815ba674eddc3c25028238f74d7b8068902b3968cbe456771b166455e/greenlet-3.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:04b013dc07c96f83134b1e99888e7a79979f1a247e2a9f59697fa14b5862ed01", size = 1122731, upload-time = "2024-09-20T17:44:20.556Z" },
@@ -2962,14 +2959,10 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "pip-audit" },
     { name = "pre-commit" },
     { name = "python-dotenv" },
     { name = "ruff" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "pip-audit" },
 ]
 
 [package.metadata]
@@ -2984,6 +2977,7 @@ requires-dist = [
     { name = "enlighten", specifier = ">=1.13.0" },
     { name = "fastexcel", specifier = ">=0.12.1" },
     { name = "pandas", specifier = ">=2.2.3" },
+    { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.10.0" },
     { name = "polars", specifier = ">=1.21.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.4" },
@@ -2995,9 +2989,6 @@ requires-dist = [
     { name = "sqlfluff-templater-dbt", specifier = ">=3.4.0" },
 ]
 provides-extras = ["dev"]
-
-[package.metadata.requires-dev]
-dev = [{ name = "pip-audit", specifier = ">=2.10.0" }]
 
 [[package]]
 name = "types-setuptools"


### PR DESCRIPTION
## Description

Cette PR modifie la stratégie de matérialisation de plusieurs modèles dbt “latest_registry_*” côté Trackdéchets, et met à jour le lockfile `uv.lock` (normalisation des dépendances dev / wheels).

### Type de changement
- [ ] Nouvelle fonctionnalité (ajout d'un pipeline, transformation, etc.)
- [ ] Correction de bug
- [x] Refactorisation
- [ ] Amélioration de performance
- [ ] Documentation
- [x] Infrastructure / Configuration
- [ ] Autre (précisez):

## Changements techniques

### Code
- Aucun changement applicatif (uniquement dbt + lockfile).

### Data
- **Modèles dbt concernés** (trusted_zone / trackdechets) :
  - `latest_registry_incoming_texs`
  - `latest_registry_incoming_waste`
  - `latest_registry_outgoing_texs`
  - `latest_registry_outgoing_waste`
  - `latest_registry_ssd`
  - `latest_registry_transported`
- **Changement principal** : passage de `materialized='incremental'` (delete+insert, `unique_key=['id']`, `on_schema_change='append_new_columns'`) à `materialized='table'`.
- **Logique métier inchangée** : les modèles continuent de filtrer `where is_latest and not is_cancelled` depuis leurs sources `registry_*`.
- **Impact attendu** :
  - Rebuild complet des tables à chaque exécution (au lieu d’un traitement incrémental).
  - Peut **augmenter le temps/coût** d’exécution, mais **réduit le risque d’incohérences** liées à l’incrémental (stale rows / gestion de schéma).

### Infrastructure
- `uv.lock` :
  - Nettoyage/normalisation des entrées wheels (ex: suppression d’entrées “deprecated”).
  - `pip-audit` est désormais bien porté par l’extra `dev` (optional-dependencies + marker `extra == 'dev'`).

## Testing

### Tests unitaires / Intégration
- [ ] Tests ajoutés/modifiés
- [ ] Tous les tests passent (`pytest`, `dbt test`, etc.)
